### PR TITLE
feat(generate): rename cheminfo org to cheminfo-js

### DIFF
--- a/bin/cheminfo-generate.js
+++ b/bin/cheminfo-generate.js
@@ -22,7 +22,7 @@ co(function *() {
             type: 'list',
             message: 'Choose an organization',
             name: 'org',
-            choices: ['ml', 'cheminfo'],
+            choices: ['ml', 'cheminfo-js'],
             default: 'ml'
         })).org;
 
@@ -34,7 +34,7 @@ co(function *() {
             });
             break;
 
-        case 'cheminfo':
+        case 'cheminfo-js':
             env.register(require.resolve('generator-cheminfo-js'), 'cheminfo-js:app');
             env.run('cheminfo-js:app', function (err) {
                 if (err) console.error(err);


### PR DESCRIPTION
The cheminfo-js packages are for browser publication. For example they include cheminfo-tools to build the browser files in `dist`.
This is not the case for general cheminfo packages that we publish on npm. We would need another template for these.
