### PR TITLE
Typedoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,11 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
@@ -6133,6 +6138,14 @@
         "vm-browserify": "0.0.4"
       }
     },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -8411,6 +8424,14 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "requires": {
         "through2": "^2.0.3"
+      }
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "requires": {
+        "nopt": "~1.0.10"
       }
     },
     "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,68 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/fs-extra": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/handlebars": {
+      "version": "4.0.39",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
+      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA=="
+    },
+    "@types/highlight.js": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
+    },
+    "@types/lodash": {
+      "version": "4.14.116",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
+      "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg=="
+    },
+    "@types/marked": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.1.tgz",
+      "integrity": "sha512-ZqEGxppVG1x9QK/hkHxzmf6m4xcnk9CaHjNCqwvUeN3pMdCcQkPxmvrbLZ5GbP7K25TgiT1nKIGnz0U3M+G05Q=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
+    "@types/node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.2.tgz",
+      "integrity": "sha512-pwZnkVyCGJ3LsQ0/3flQK5lCFao4esIzwUVzzk5NvL9vnkEyDhNf4fhHzUMHvyr56gNZywWTS2MR0euabMSz4A=="
+    },
+    "@types/shelljs": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
+      "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
     "JSONStream": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
@@ -3352,6 +3414,16 @@
       "resolved": "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz",
       "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ=="
     },
+    "fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -5077,6 +5149,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -5410,6 +5490,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
       "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
+    },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
     },
     "md5.js": {
       "version": "1.3.4",
@@ -6651,6 +6736,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -7995,6 +8085,37 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "supports-hyperlinks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+      "requires": {
+        "has-flag": "^2.0.0",
+        "supports-color": "^5.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            }
+          }
+        }
+      }
+    },
     "tabtab": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
@@ -8129,6 +8250,15 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+    },
+    "terminal-link": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-1.1.0.tgz",
+      "integrity": "sha512-sOZb3eUbMEcBeuA+TePxEiyueKHNoFOdU8gJtw6vXBKQEgj2ZeyQfWT0aXqjSDI1a/xEZfjzTZMApcSgV70KGg==",
+      "requires": {
+        "ansi-escapes": "^3.1.0",
+        "supports-hyperlinks": "^1.0.1"
+      }
     },
     "text-extensions": {
       "version": "1.7.0",
@@ -8361,6 +8491,40 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typedoc": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
+      "integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
+      "requires": {
+        "@types/fs-extra": "^5.0.3",
+        "@types/handlebars": "^4.0.38",
+        "@types/highlight.js": "^9.12.3",
+        "@types/lodash": "^4.14.110",
+        "@types/marked": "^0.4.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "^0.8.0",
+        "fs-extra": "^7.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.0.0",
+        "lodash": "^4.17.10",
+        "marked": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.2",
+        "typedoc-default-themes": "^0.5.0",
+        "typescript": "3.0.x"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
+    },
+    "typescript": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg=="
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -8548,6 +8712,11 @@
       "requires": {
         "unist-util-is": "^2.1.2"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "semver": "^5.3.0",
     "tabtab": "^2.2.1",
     "terminal-link": "^1.1.0",
+    "touch": "^3.1.0",
     "typedoc": "^0.12.0",
     "uglifyjs-webpack-plugin": "^1.1.2",
     "webpack": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "request-promise": "^4.0.1",
     "semver": "^5.3.0",
     "tabtab": "^2.2.1",
+    "terminal-link": "^1.1.0",
+    "typedoc": "^0.12.0",
     "uglifyjs-webpack-plugin": "^1.1.2",
     "webpack": "^3.9.1",
     "yeoman-environment": "^2.0.0"

--- a/src/generateDoc.js
+++ b/src/generateDoc.js
@@ -5,6 +5,7 @@ const terminalLink = require('terminal-link');
 const fs = require('mz/fs');
 const inquirer = require('inquirer');
 const path = require('path');
+const touch = require('touch');
 const { detectTypescript, detectTypedoc } = require('./util');
 
 module.exports = function* generateDoc(publish) {
@@ -38,6 +39,7 @@ module.exports = function* generateDoc(publish) {
         );
       }
       yield execa(documentationExecPath, typedocArgs);
+      yield touch('docs/.nojekyll');
     } else {
       const documentationLibLink = terminalLink(
         'documentation',

--- a/src/generateDoc.js
+++ b/src/generateDoc.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const execa = require('execa');
+const terminalLink = require('terminal-link');
 const fs = require('mz/fs');
 const inquirer = require('inquirer');
 const path = require('path');
+const { detectTypescript, detectTypedoc } = require('./util');
 
 module.exports = function* generateDoc(publish) {
   const hasDoc = yield fs.exists('docs');
@@ -18,22 +20,48 @@ module.exports = function* generateDoc(publish) {
     })).c;
   }
   if (wantsDoc) {
-    const documentationExecPath = path.resolve(
-      __dirname,
-      '../node_modules/.bin/documentation'
-    );
-    const pkg = require(process.cwd() + '/package.json');
-    const main = pkg.module || pkg.main || '';
-    yield execa(documentationExecPath, [
-      'build',
-      main,
-      '--github',
-      '--output docs',
-      '--format',
-      'html',
-      '--sort-order',
-      'alpha'
-    ]);
+    const isTypescript = yield detectTypescript();
+    if (isTypescript) {
+      const hasTypedocConfig = yield detectTypedoc();
+      const typedocLink = terminalLink('typedoc', 'https://typedoc.org/');
+      console.log('generating docs for typescript project with', typedocLink);
+      const documentationExecPath = path.resolve(
+        __dirname,
+        '../node_modules/.bin/typedoc'
+      );
+      const typedocArgs = ['--out', 'docs', 'src/index.ts'];
+      if (hasTypedocConfig) {
+        typedocArgs.push('--options', 'typedoc.config.js');
+      } else {
+        console.log(
+          'you can customize the output by writing a typedoc.config.js file'
+        );
+      }
+      yield execa(documentationExecPath, typedocArgs);
+    } else {
+      const documentationLibLink = terminalLink(
+        'documentation',
+        'https://github.com/documentationjs/documentation'
+      );
+      console.log('generating js docs with', documentationLibLink);
+
+      const documentationExecPath = path.resolve(
+        __dirname,
+        '../node_modules/.bin/documentation'
+      );
+      const pkg = require(process.cwd() + '/package.json');
+      const main = pkg.module || pkg.main || '';
+      yield execa(documentationExecPath, [
+        'build',
+        main,
+        '--github',
+        '--output docs',
+        '--format',
+        'html',
+        '--sort-order',
+        'alpha'
+      ]);
+    }
     if (publish) {
       yield execa('git', ['add', 'docs']);
       yield execa('git', ['commit', '-m', 'doc: rebuild docs [ci skip]']);

--- a/src/util.js
+++ b/src/util.js
@@ -3,41 +3,48 @@
 const getLatestVersion = require('latest-version');
 const semver = require('semver');
 const githubParser = require('parse-github-repo-url');
-
+const fs = require('mz/fs');
 
 const pack = require('../package.json');
 
-exports.checkLatestVersion = function* (force) {
-    if (force) return false;
+exports.checkLatestVersion = function*(force) {
+  if (force) return false;
 
-    const latestVersion = yield getLatestVersion('cheminfo-tools');
-    const thisVersion = pack.version;
-    if (semver.gt(latestVersion, thisVersion)) {
-        console.error(`Your version of cheminfo-tools (${thisVersion}) is obsolete. Latest is ${latestVersion}.
+  const latestVersion = yield getLatestVersion('cheminfo-tools');
+  const thisVersion = pack.version;
+  if (semver.gt(latestVersion, thisVersion)) {
+    console.error(`Your version of cheminfo-tools (${thisVersion}) is obsolete. Latest is ${latestVersion}.
 Please upgrade using the command: npm install -g cheminfo-tools`);
-        return true;
-    }
+    return true;
+  }
 
-    return false;
+  return false;
 };
 
-exports.getOrgFromPackage = function (pkg) {
-    try {
-        let url;
-        if (typeof pkg.repository === 'string') {
-            url = pkg.repository;
-            // return githubParser(pkg.repository)[0];
-        } else if (pkg.repository && pkg.repository.url) {
-            url = pkg.repository.url;
-        } else if (pkg.bugs && pkg.bugs.url) {
-            url = pkg.bugs.url;
-        } else if (pkg.homepage) {
-            url = pkg.homepage;
-        }
-
-        return githubParser(url)[0];
-    } catch (e) {
-        // ignore
+exports.getOrgFromPackage = function(pkg) {
+  try {
+    let url;
+    if (typeof pkg.repository === 'string') {
+      url = pkg.repository;
+      // return githubParser(pkg.repository)[0];
+    } else if (pkg.repository && pkg.repository.url) {
+      url = pkg.repository.url;
+    } else if (pkg.bugs && pkg.bugs.url) {
+      url = pkg.bugs.url;
+    } else if (pkg.homepage) {
+      url = pkg.homepage;
     }
 
+    return githubParser(url)[0];
+  } catch (e) {
+    // ignore
+  }
+};
+
+exports.detectTypescript = function*() {
+  return yield fs.exists('tsconfig.json');
+};
+
+exports.detectTypedoc = function*() {
+  return yield fs.exists('typedoc.config.js');
 };


### PR DESCRIPTION
Doc generation will detect presence of `tsconfig.json` file to determine if it is a typescript project.
It will also detect the presence of a `typedoc.config.js` file so that each project can specify non-default options to typedoc.
I also tried to use `terminal-link` but on my terminal the links just appear as normal text.

Example of documentation with typedoc: https://cheminfo.github.io/well-plates/