### PR TITLE
chore: resolve to node-resolve

### DIFF
--- a/packages/cheminfo-build/bin/cheminfo-build.js
+++ b/packages/cheminfo-build/bin/cheminfo-build.js
@@ -9,7 +9,7 @@ const rollup = require('rollup');
 const babel = require('rollup-plugin-babel');
 const commonjs = require('@rollup/plugin-commonjs');
 const json = require('@rollup/plugin-json');
-const resolve = require('@rollup/plugin-node-resolve');
+const nodeResolve = require('@rollup/plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
 const yargs = require('yargs');
 
@@ -106,7 +106,7 @@ function getInputOptions(options = {}) {
   const rollupOptions = {
     input: path.resolve(cwd, entryPoint),
     plugins: [
-      resolve({ browser: true }),
+      nodeResolve({ browser: true }),
       commonjs({ namedExports }),
       json(),
       babel({

--- a/packages/cheminfo-build/bin/cheminfo-build.js
+++ b/packages/cheminfo-build/bin/cheminfo-build.js
@@ -9,7 +9,7 @@ const rollup = require('rollup');
 const babel = require('rollup-plugin-babel');
 const commonjs = require('@rollup/plugin-commonjs');
 const json = require('@rollup/plugin-json');
-const nodeResolve = require('@rollup/plugin-node-resolve');
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const { terser } = require('rollup-plugin-terser');
 const yargs = require('yargs');
 


### PR DESCRIPTION
I ran into a `TypeError: resolve is not a function` which is basically  https://github.com/rollup/plugins/issues/439. This PR incorporates the change recommended there.
Background discussed in https://github.com/rollup/plugins/pull/456.