### PR TITLE
chore: remove namedExports option, add nodePolyFills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 
 test/fixtures/*/dist
+.DS_Store

--- a/packages/cheminfo-build/bin/cheminfo-build.js
+++ b/packages/cheminfo-build/bin/cheminfo-build.js
@@ -69,9 +69,6 @@ if (!name) {
 
 const filename = program.outName || pkg.name || 'bundle';
 
-const { build = {} } = pkg.cheminfo;
-const { namedExports = {} } = build;
-
 runBuild().catch((e) => {
   console.error(e);
   process.exit(1);
@@ -107,7 +104,7 @@ function getInputOptions(options = {}) {
     input: path.resolve(cwd, entryPoint),
     plugins: [
       nodeResolve({ browser: true }),
-      commonjs({ namedExports }),
+      commonjs(),
       json(),
       babel({
         babelrc: false,


### PR DESCRIPTION
-The namedExports option from @rollup/plugin-commonjs is deprecated. Named exports are now handled automatically.
https://github.com/rollup/plugins/pull/410 